### PR TITLE
Fix nullification bug

### DIFF
--- a/src/Bridge.sol
+++ b/src/Bridge.sol
@@ -93,7 +93,7 @@ contract Bridge is IBridge {
 
         ebtc.mint(depositor, txOut2Value);
 
-        pegIns[proof2.txId] = true;
+        pegIns[proof1.txId] = true;
 
         emit PegInMinted(depositor, txOut2Value, depositorPubKey);
     }

--- a/test/PegIn.t.sol
+++ b/test/PegIn.t.sol
@@ -46,6 +46,30 @@ contract PegInTest is StorageFixture {
         assertEq(true, true);
     }
 
+    function testPegIn_pegIn_PegInInvalid() public {
+        StorageSetupInfo memory initNormal = getNormalSetupInfo();
+        StorageSetupResult memory fixture = buildStorage(initNormal);
+
+        ProofParam memory proofParam1 = getPegInProofParamNormal(1);
+        ProofParam memory proofParam2 = getPegInProofParamNormal(2);
+
+        ProofInfo memory proof1 = Util.paramToProof(proofParam1, false);
+        ProofInfo memory proof2 = Util.paramToProof(proofParam2, false);
+
+        IBridge bridge = IBridge(fixture.bridge);
+        address depositor = 0xDDdDddDdDdddDDddDDddDDDDdDdDDdDDdDDDDDDd;
+        address operator = fixture.operator;
+
+        vm.startPrank(operator);
+        bridge.pegIn(depositor, DEPOSITOR_PUBKEY, proof1, proof2);
+
+        vm.expectRevert(abi.encodeWithSelector(IBridge.PegInInvalid.selector));
+        bridge.pegIn(depositor, DEPOSITOR_PUBKEY, proof1, proof2);
+        vm.stopPrank();
+
+        assertEq(IERC20(fixture.ebtc).balanceOf(depositor), 131072);
+    }
+
     function testPegIn_pegIn_file() public {
         if (!data.valid()) {
             console.log("Invalid Data file");


### PR DESCRIPTION
`pegIn` function does the nullification check against `proof1.txId`

```solidity
if (isPegInExist(proof1.txId)) {
            revert PegInInvalid();
}
```

but then stores `proof2.txId` as nullifier.

```
pegIns[proof2.txId] = true;
```
Thus the same tx pair can be spent twice leading to a critical vulnerability.  This can be proven by modifying the following test as such with two `pegIn` calls. Doing the fix resolves the issue. A double spend test should be added as well.

```solidity
    function testPegIn_pegIn_normal() public {
        StorageSetupInfo memory initNormal = getNormalSetupInfo();
        StorageSetupResult memory fixture = buildStorage(initNormal);

        ProofParam memory proofParam1 = getPegInProofParamNormal(1);
        ProofParam memory proofParam2 = getPegInProofParamNormal(2);

        ProofInfo memory proof1 = Util.paramToProof(proofParam1, false);
        ProofInfo memory proof2 = Util.paramToProof(proofParam2, false);

        IBridge bridge = IBridge(fixture.bridge);
        address depositor = 0xDDdDddDdDdddDDddDDddDDDDdDdDDdDDdDDDDDDd;
        address operator = fixture.operator;

        vm.startPrank(operator);
        vm.expectEmit(true, true, true, true, address(bridge));
        emit IBridge.PegInMinted(depositor, 131072, DEPOSITOR_PUBKEY);
        uint256 gas = gasleft();
        bridge.pegIn(depositor, DEPOSITOR_PUBKEY, proof1, proof2);
        bridge.pegIn(depositor, DEPOSITOR_PUBKEY, proof1, proof2);
        uint256 gasUsed = gas - gasleft();
        console.log("pegIn gas used: ", gasUsed);
        vm.stopPrank();

        assertEq(true, true);
    }
    ```
    